### PR TITLE
docs: fix simple typo, folowing -> following

### DIFF
--- a/linux-net-kernel/net/8021q/vlanproc.c
+++ b/linux-net-kernel/net/8021q/vlanproc.c
@@ -54,7 +54,7 @@ static const char name_conf[]	 = "config";
 
 /*
  *	Structures for interfacing with the /proc filesystem.
- *	VLAN creates its own directory /proc/net/vlan with the folowing
+ *	VLAN creates its own directory /proc/net/vlan with the following
  *	entries:
  *	config		device status/configuration
  *	<device>	entry for each  device

--- a/linux-net-kernel/net/wanrouter/wanproc.c
+++ b/linux-net-kernel/net/wanrouter/wanproc.c
@@ -51,7 +51,7 @@
 
 /*
  *	Structures for interfacing with the /proc filesystem.
- *	Router creates its own directory /proc/net/router with the folowing
+ *	Router creates its own directory /proc/net/router with the following
  *	entries:
  *	config		device configuration
  *	status		global device statistics


### PR DESCRIPTION
There is a small typo in linux-net-kernel/net/8021q/vlanproc.c, linux-net-kernel/net/wanrouter/wanproc.c.

Should read `following` rather than `folowing`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md